### PR TITLE
fix various warnings

### DIFF
--- a/TelepathyQt/abstract-client.cpp
+++ b/TelepathyQt/abstract-client.cpp
@@ -758,7 +758,7 @@ void AbstractClientHandler::Capabilities::unsetToken(const QString &token)
 
 QStringList AbstractClientHandler::Capabilities::allTokens() const
 {
-    return mPriv->tokens.toList();
+    return mPriv->tokens.values();
 }
 
 struct TP_QT_NO_EXPORT AbstractClientHandler::HandlerInfo::Private : public QSharedData

--- a/TelepathyQt/abstract-client.cpp
+++ b/TelepathyQt/abstract-client.cpp
@@ -711,7 +711,11 @@ struct TP_QT_NO_EXPORT AbstractClientHandler::Private
 struct TP_QT_NO_EXPORT AbstractClientHandler::Capabilities::Private : public QSharedData
 {
     Private(const QStringList &tokens)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        : tokens(tokens.isEmpty() ? QSet<QString>() : QSet<QString>(tokens.begin(), tokens.end())) {}
+#else
         : tokens(QSet<QString>::fromList(tokens)) {}
+#endif
 
     QSet<QString> tokens;
 };

--- a/TelepathyQt/base-channel.cpp
+++ b/TelepathyQt/base-channel.cpp
@@ -298,10 +298,10 @@ Tp::ChannelDetails BaseChannel::details() const
 {
     Tp::ChannelDetails details;
     details.channel = QDBusObjectPath(objectPath());
-    details.properties.unite(immutableProperties());
+    details.properties.insert(immutableProperties());
 
     foreach(const AbstractChannelInterfacePtr & iface, mPriv->interfaces) {
-        details.properties.unite(iface->immutableProperties());
+        details.properties.insert(iface->immutableProperties());
     }
 
     return details;

--- a/TelepathyQt/base-connection-manager.cpp
+++ b/TelepathyQt/base-connection-manager.cpp
@@ -383,7 +383,7 @@ bool BaseConnectionManager::registerObject(const QString &busName, const QString
  */
 QList<BaseConnectionPtr> BaseConnectionManager::connections() const
 {
-    return mPriv->connections.toList();
+    return mPriv->connections.values();
 }
 
 void BaseConnectionManager::addConnection(const BaseConnectionPtr &connection)

--- a/TelepathyQt/base-protocol.cpp
+++ b/TelepathyQt/base-protocol.cpp
@@ -220,7 +220,7 @@ QVariantMap BaseProtocol::immutableProperties() const
 {
     QVariantMap ret;
     foreach (const AbstractProtocolInterfacePtr &iface, mPriv->interfaces) {
-        ret.unite(iface->immutableProperties());
+        ret.insert(iface->immutableProperties());
     }
     ret.insert(TP_QT_IFACE_PROTOCOL + QLatin1String(".Interfaces"),
             QVariant::fromValue(mPriv->adaptee->interfaces()));

--- a/TelepathyQt/call-channel.cpp
+++ b/TelepathyQt/call-channel.cpp
@@ -526,11 +526,11 @@ CallMemberFlags CallChannel::remoteMemberFlags(const ContactPtr &member) const
 {
     if (!isReady(FeatureCallMembers)) {
         warning() << "CallChannel::remoteMemberFlags() used with FeatureCallMembers not ready";
-        return (CallMemberFlags) nullptr;
+        return CallMemberFlags();
     }
 
     if (!member) {
-        return (CallMemberFlags) nullptr;
+        return CallMemberFlags();
     }
 
     for (CallMemberMap::const_iterator i = mPriv->callMembers.constBegin();
@@ -543,7 +543,7 @@ CallMemberFlags CallChannel::remoteMemberFlags(const ContactPtr &member) const
         }
     }
 
-    return (CallMemberFlags) nullptr;
+    return CallMemberFlags();
 }
 
 /**

--- a/TelepathyQt/call-channel.cpp
+++ b/TelepathyQt/call-channel.cpp
@@ -505,7 +505,12 @@ Contacts CallChannel::remoteMembers() const
         return Contacts();
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    auto mem = mPriv->callMembersContacts.values();
+    return mem.isEmpty() ? Contacts() : Contacts(mem.begin(), mem.end());
+#else
     return mPriv->callMembersContacts.values().toSet();
+#endif
 }
 
 /**
@@ -1008,7 +1013,13 @@ void CallChannel::gotCallMembersContacts(PendingOperation *op)
         }
 
         if (!removed.isEmpty()) {
-            emit remoteMembersRemoved(removed.values().toSet(),
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+            auto rem = removed.values();
+            Contacts removedMembers(rem.begin(), rem.end());
+#else
+            Contacts removedMembers = removed.values().toSet();
+#endif
+            emit remoteMembersRemoved(removedMembers,
                     mPriv->currentCallMembersChangedInfo->reason);
         }
     }

--- a/TelepathyQt/call-channel.cpp
+++ b/TelepathyQt/call-channel.cpp
@@ -319,7 +319,7 @@ void CallChannel::Private::processCallMembersChanged()
 
         ContactManagerPtr contactManager = connection->contactManager();
         PendingContacts *contacts = contactManager->contactsForHandles(
-                pendingCallMembers.toList());
+                pendingCallMembers.values());
         parent->connect(contacts,
                 SIGNAL(finished(Tp::PendingOperation*)),
                 SLOT(gotCallMembersContacts(Tp::PendingOperation*)));

--- a/TelepathyQt/call-stream.cpp
+++ b/TelepathyQt/call-stream.cpp
@@ -170,7 +170,7 @@ void CallStream::Private::processRemoteMembersChanged()
 
         ContactManagerPtr contactManager = connection->contactManager();
         PendingContacts *contacts = contactManager->contactsForHandles(
-                pendingRemoteMembers.toList());
+                pendingRemoteMembers.values());
         parent->connect(contacts,
                 SIGNAL(finished(Tp::PendingOperation*)),
                 SLOT(gotRemoteMembersContacts(Tp::PendingOperation*)));

--- a/TelepathyQt/call-stream.cpp
+++ b/TelepathyQt/call-stream.cpp
@@ -260,7 +260,12 @@ bool CallStream::canRequestReceiving() const
  */
 Contacts CallStream::remoteMembers() const
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    auto mem = mPriv->remoteMembersContacts.values();
+    return mem.isEmpty() ? Contacts() : Contacts(mem.begin(), mem.end());
+#else
     return mPriv->remoteMembersContacts.values().toSet();
+#endif
 }
 
 /**
@@ -431,7 +436,13 @@ void CallStream::gotRemoteMembersContacts(PendingOperation *op)
         }
 
         if (!removed.isEmpty()) {
-            emit remoteMembersRemoved(removed.values().toSet(),
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+            auto mem = removed.values();
+            Contacts removedMembers(mem.begin(), mem.end());
+#else
+            Contacts removedMembers = removed.values().toSet();
+#endif
+            emit remoteMembersRemoved(removedMembers,
                     mPriv->currentRemoteMembersChangedInfo->reason);
         }
     }

--- a/TelepathyQt/channel-class-spec.h
+++ b/TelepathyQt/channel-class-spec.h
@@ -309,14 +309,24 @@ inline uint qHash(const QSet<ChannelClassSpec> &specSet)
 inline uint qHash(const ChannelClassSpecList &specList)
 {
     // Make it unique by converting to QSet
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    QSet<ChannelClassSpec> uniqueSet = specList.isEmpty() ? QSet<ChannelClassSpec>() :
+            QSet<ChannelClassSpec>(specList.begin(), specList.end());
+#else
     QSet<ChannelClassSpec> uniqueSet = specList.toSet();
+#endif
     return qHash(uniqueSet);
 }
 
 inline uint qHash(const QList<ChannelClassSpec> &specList)
 {
     // Make it unique by converting to QSet
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    QSet<ChannelClassSpec> uniqueSet = specList.isEmpty() ? QSet<ChannelClassSpec>() :
+            QSet<ChannelClassSpec>(specList.begin(), specList.end());
+#else
     QSet<ChannelClassSpec> uniqueSet = specList.toSet();
+#endif
     return qHash(uniqueSet);
 }
 

--- a/TelepathyQt/channel.cpp
+++ b/TelepathyQt/channel.cpp
@@ -3138,13 +3138,19 @@ void Channel::gotContacts(PendingOperation *op)
 void Channel::onGroupFlagsChanged(uint added, uint removed)
 {
     debug().nospace() << "Got Channel.Interface.Group::GroupFlagsChanged(" <<
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        Qt::
+#endif
         hex << added << ", " << removed << ")";
 
     added &= ~(mPriv->groupFlags);
     removed &= mPriv->groupFlags;
 
-    debug().nospace() << "Arguments after filtering (" << hex << added <<
-        ", " << removed << ")";
+    debug().nospace() << "Arguments after filtering (" <<
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        Qt::
+#endif
+        hex << added << ", " << removed << ")";
 
     uint groupFlags = mPriv->groupFlags;
     groupFlags |= added;

--- a/TelepathyQt/channel.cpp
+++ b/TelepathyQt/channel.cpp
@@ -834,7 +834,7 @@ void Channel::Private::buildContacts()
     ContactManagerPtr manager = connection->contactManager();
     UIntList toBuild = QSet<uint>(pendingGroupMembers +
             pendingGroupLocalPendingMembers +
-            pendingGroupRemotePendingMembers).toList();
+            pendingGroupRemotePendingMembers).values();
 
     if (currentGroupMembersChangedInfo &&
             currentGroupMembersChangedInfo->actor != 0) {

--- a/TelepathyQt/channel.cpp
+++ b/TelepathyQt/channel.cpp
@@ -2374,7 +2374,12 @@ Contacts Channel::groupContacts(bool includeSelfContact) const
         warning() << "Channel::groupMembers() used channel not ready";
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    auto c = mPriv->groupContacts.values();
+    Contacts ret = c.isEmpty() ? Contacts() : Contacts(c.begin(), c.end());
+#else
     Contacts ret = mPriv->groupContacts.values().toSet();
+#endif
     if (!includeSelfContact) {
         ret.remove(groupSelfContact());
     }
@@ -2405,7 +2410,12 @@ Contacts Channel::groupLocalPendingContacts(bool includeSelfContact) const
         warning() << "Channel::groupLocalPendingContacts() used with no group interface";
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    auto c = mPriv->groupLocalPendingContacts.values();
+    Contacts ret = c.isEmpty() ? Contacts() : Contacts(c.begin(), c.end());
+#else
     Contacts ret = mPriv->groupLocalPendingContacts.values().toSet();
+#endif
     if (!includeSelfContact) {
         ret.remove(groupSelfContact());
     }
@@ -2437,7 +2447,12 @@ Contacts Channel::groupRemotePendingContacts(bool includeSelfContact) const
             "group interface";
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    auto c = mPriv->groupRemotePendingContacts.values();
+    Contacts ret = c.isEmpty() ? Contacts() : Contacts(c.begin(), c.end());
+#else
     Contacts ret = mPriv->groupRemotePendingContacts.values().toSet();
+#endif
     if (!includeSelfContact) {
         ret.remove(groupSelfContact());
     }
@@ -3424,7 +3439,13 @@ void Channel::gotConferenceInitialInviteeContacts(PendingOperation *op)
     PendingContacts *pending = qobject_cast<PendingContacts *>(op);
 
     if (pending->isValid()) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        auto c = pending->contacts();
+        mPriv->conferenceInitialInviteeContacts = c.isEmpty() ? Contacts() :
+                Contacts(c.begin(), c.end());
+#else
         mPriv->conferenceInitialInviteeContacts = pending->contacts().toSet();
+#endif
     } else {
         warning().nospace() << "Getting conference initial invitee contacts "
             "failed with " << pending->errorName() << ":" <<

--- a/TelepathyQt/client-registrar-internal.h
+++ b/TelepathyQt/client-registrar-internal.h
@@ -23,6 +23,8 @@
 #ifndef _TelepathyQt_client_registrar_internal_h_HEADER_GUARD_
 #define _TelepathyQt_client_registrar_internal_h_HEADER_GUARD_
 
+#include <list>
+
 #include <QtCore/QObject>
 #include <QtDBus/QtDBus>
 
@@ -142,7 +144,7 @@ private:
         QList<ChannelRequestPtr> chanReqs;
         AbstractClientObserver::ObserverInfo observerInfo;
     };
-    QLinkedList<SharedPtr<InvocationData> > mInvocations;
+    std::list<SharedPtr<InvocationData> > mInvocations;
 
     ClientRegistrar *mRegistrar;
     QDBusConnection mBus;
@@ -204,7 +206,7 @@ private:
         QList<ChannelPtr> chans;
         ChannelDispatchOperationPtr dispatchOp;
     };
-    QLinkedList<SharedPtr<InvocationData> > mInvocations;
+    std::list<SharedPtr<InvocationData> > mInvocations;
 
 private:
     ClientRegistrar *mRegistrar;
@@ -298,7 +300,7 @@ private:
         QDateTime time;
         AbstractClientHandler::HandlerInfo handlerInfo;
     };
-    QLinkedList<SharedPtr<InvocationData> > mInvocations;
+    std::list<SharedPtr<InvocationData> > mInvocations;
 
 private:
     static void onContextFinished(const MethodInvocationContextPtr<> &context,

--- a/TelepathyQt/client-registrar.cpp
+++ b/TelepathyQt/client-registrar.cpp
@@ -212,7 +212,7 @@ void ClientObserverAdaptor::ObserveChannels(const QDBusObjectPath &accountPath,
             SIGNAL(finished(Tp::PendingOperation*)),
             SLOT(onReadyOpFinished(Tp::PendingOperation*)));
 
-    mInvocations.append(invocation);
+    mInvocations.push_back(invocation);
 
     debug() << "Preparing proxies for ObserveChannels of" << channelDetailsList.size() << "channels"
         << "for client" << mClient;
@@ -220,29 +220,29 @@ void ClientObserverAdaptor::ObserveChannels(const QDBusObjectPath &accountPath,
 
 void ClientObserverAdaptor::onReadyOpFinished(Tp::PendingOperation *op)
 {
-    Q_ASSERT(!mInvocations.isEmpty());
+    Q_ASSERT(!mInvocations.empty());
     Q_ASSERT(op->isFinished());
 
-    for (QLinkedList<SharedPtr<InvocationData> >::iterator i = mInvocations.begin();
-            i != mInvocations.end(); ++i) {
-        if ((*i)->readyOp != op) {
+    for (const auto &i : mInvocations) {
+        if (i->readyOp != op) {
             continue;
         }
 
-        (*i)->readyOp = nullptr;
+        i->readyOp = nullptr;
 
         if (op->isError()) {
             warning() << "Preparing proxies for ObserveChannels failed with" << op->errorName()
                 << op->errorMessage();
-            (*i)->error = op->errorName();
-            (*i)->message = op->errorMessage();
+            i->error = op->errorName();
+            i->message = op->errorMessage();
         }
 
         break;
     }
 
-    while (!mInvocations.isEmpty() && !mInvocations.first()->readyOp) {
-        SharedPtr<InvocationData> invocation = mInvocations.takeFirst();
+    while (!mInvocations.empty() && !mInvocations.front()->readyOp) {
+        auto invocation = mInvocations.front();
+        mInvocations.pop_front();
 
         if (!invocation->error.isEmpty()) {
             // We guarantee that the proxies were ready - so we can't invoke the client if they
@@ -318,34 +318,34 @@ void ClientApproverAdaptor::AddDispatchOperation(const Tp::ChannelDetailsList &c
             SIGNAL(finished(Tp::PendingOperation*)),
             SLOT(onReadyOpFinished(Tp::PendingOperation*)));
 
-    mInvocations.append(invocation);
+    mInvocations.push_back(invocation);
 }
 
 void ClientApproverAdaptor::onReadyOpFinished(Tp::PendingOperation *op)
 {
-    Q_ASSERT(!mInvocations.isEmpty());
+    Q_ASSERT(!mInvocations.empty());
     Q_ASSERT(op->isFinished());
 
-    for (QLinkedList<SharedPtr<InvocationData> >::iterator i = mInvocations.begin();
-            i != mInvocations.end(); ++i) {
-        if ((*i)->readyOp != op) {
+    for (const auto &i : mInvocations) {
+        if (i->readyOp != op) {
             continue;
         }
 
-        (*i)->readyOp = nullptr;
+        i->readyOp = nullptr;
 
         if (op->isError()) {
             warning() << "Preparing proxies for AddDispatchOperation failed with" << op->errorName()
                 << op->errorMessage();
-            (*i)->error = op->errorName();
-            (*i)->message = op->errorMessage();
+            i->error = op->errorName();
+            i->message = op->errorMessage();
         }
 
         break;
     }
 
-    while (!mInvocations.isEmpty() && !mInvocations.first()->readyOp) {
-        SharedPtr<InvocationData> invocation = mInvocations.takeFirst();
+    while (!mInvocations.empty() && !mInvocations.front()->readyOp) {
+        auto invocation = mInvocations.front();
+        mInvocations.pop_front();
 
         if (!invocation->error.isEmpty()) {
             // We guarantee that the proxies were ready - so we can't invoke the client if they
@@ -473,7 +473,7 @@ void ClientHandlerAdaptor::HandleChannels(const QDBusObjectPath &accountPath,
             SIGNAL(finished(Tp::PendingOperation*)),
             SLOT(onReadyOpFinished(Tp::PendingOperation*)));
 
-    mInvocations.append(invocation);
+    mInvocations.push_front(invocation);
 
     debug() << "Preparing proxies for HandleChannels of" << channelDetailsList.size() << "channels"
         << "for client" << mClient;
@@ -481,29 +481,29 @@ void ClientHandlerAdaptor::HandleChannels(const QDBusObjectPath &accountPath,
 
 void ClientHandlerAdaptor::onReadyOpFinished(Tp::PendingOperation *op)
 {
-    Q_ASSERT(!mInvocations.isEmpty());
+    Q_ASSERT(!mInvocations.empty());
     Q_ASSERT(op->isFinished());
 
-    for (QLinkedList<SharedPtr<InvocationData> >::iterator i = mInvocations.begin();
-            i != mInvocations.end(); ++i) {
-        if ((*i)->readyOp != op) {
+    for (const auto &i : mInvocations) {
+        if (i->readyOp != op) {
             continue;
         }
 
-        (*i)->readyOp = nullptr;
+        i->readyOp = nullptr;
 
         if (op->isError()) {
             warning() << "Preparing proxies for HandleChannels failed with" << op->errorName()
                 << op->errorMessage();
-            (*i)->error = op->errorName();
-            (*i)->message = op->errorMessage();
+            i->error = op->errorName();
+            i->message = op->errorMessage();
         }
 
         break;
     }
 
-    while (!mInvocations.isEmpty() && !mInvocations.first()->readyOp) {
-        SharedPtr<InvocationData> invocation = mInvocations.takeFirst();
+    while (!mInvocations.empty() && !mInvocations.front()->readyOp) {
+        auto invocation = mInvocations.front();
+        mInvocations.pop_front();
 
         if (!invocation->error.isEmpty()) {
             RequestTemporaryHandler *tempHandler = dynamic_cast<RequestTemporaryHandler *>(mClient);

--- a/TelepathyQt/connection-manager.cpp
+++ b/TelepathyQt/connection-manager.cpp
@@ -83,7 +83,7 @@ void ConnectionManager::Private::PendingNames::continueProcessing()
     }
     else {
         debug() << "Success: list" << mResult;
-        setResult(mResult.toList());
+        setResult(mResult.values());
         setFinished();
     }
 }

--- a/TelepathyQt/connection.cpp
+++ b/TelepathyQt/connection.cpp
@@ -353,7 +353,7 @@ Connection::Private::~Private()
                 if (!type.toRelease.empty()) {
                     debug() << " Was going to release" <<
                         type.toRelease.size() << "handles, doing that now";
-                    baseInterface->ReleaseHandles(handleType, type.toRelease.toList());
+                    baseInterface->ReleaseHandles(handleType, type.toRelease.values());
                 }
             }
 
@@ -2373,7 +2373,7 @@ void Connection::doReleaseSweep(uint handleType)
 
     debug() << " Releasing" << handleContext->types[handleType].toRelease.size() << "handles";
 
-    mPriv->baseInterface->ReleaseHandles(handleType, handleContext->types[handleType].toRelease.toList());
+    mPriv->baseInterface->ReleaseHandles(handleType, handleContext->types[handleType].toRelease.values());
     handleContext->types[handleType].toRelease.clear();
 }
 

--- a/TelepathyQt/contact-capabilities.cpp
+++ b/TelepathyQt/contact-capabilities.cpp
@@ -121,7 +121,7 @@ QStringList ContactCapabilities::dbusTubeServices() const
         }
     }
 
-    return ret.toList();
+    return ret.values();
 }
 
 /**
@@ -162,7 +162,7 @@ QStringList ContactCapabilities::streamTubeServices() const
         }
     }
 
-    return ret.toList();
+    return ret.values();
 }
 
 } // Tp

--- a/TelepathyQt/contact-manager-roster.cpp
+++ b/TelepathyQt/contact-manager-roster.cpp
@@ -1338,7 +1338,13 @@ void ContactManager::Roster::gotContactListGroupsProperties(PendingOperation *op
 
     QVariantMap props = pvm->result();
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    auto groups = qdbus_cast<QStringList>(props[QLatin1String("Groups")]);
+    cachedAllKnownGroups = groups.isEmpty() ? QSet<QString>() :
+            QSet<QString>(groups.begin(), groups.end());
+#else
     cachedAllKnownGroups = qdbus_cast<QStringList>(props[QLatin1String("Groups")]).toSet();
+#endif
     contactListGroupPropertiesReceived = true;
 
     processingContactListChanges = true;

--- a/TelepathyQt/contact-manager-roster.cpp
+++ b/TelepathyQt/contact-manager-roster.cpp
@@ -228,7 +228,7 @@ QStringList ContactManager::Roster::allKnownGroups() const
         return contactListGroupChannels.keys();
     }
 
-    return cachedAllKnownGroups.toList();
+    return cachedAllKnownGroups.values();
 }
 
 PendingOperation *ContactManager::Roster::addGroup(const QString &group)
@@ -1343,7 +1343,7 @@ void ContactManager::Roster::gotContactListGroupsProperties(PendingOperation *op
 
     processingContactListChanges = true;
     PendingContacts *pc = contactManager->upgradeContacts(
-            contactManager->allKnownContacts().toList(),
+            contactManager->allKnownContacts().values(),
             Contact::FeatureRosterGroups);
     connect(pc,
             SIGNAL(finished(Tp::PendingOperation*)),
@@ -1694,7 +1694,7 @@ void ContactManager::Roster::introspectContactListContacts()
     interfaces.insert(TP_QT_IFACE_CONNECTION_INTERFACE_CONTACT_LIST);
 
     QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(
-            iface->GetContactListAttributes(interfaces.toList(), true), contactManager);
+            iface->GetContactListAttributes(interfaces.values(), true), contactManager);
     connect(watcher,
             SIGNAL(finished(QDBusPendingCallWatcher*)),
             SLOT(gotContactListContacts(QDBusPendingCallWatcher*)));
@@ -2172,7 +2172,7 @@ ContactManager::Roster::RemoveGroupOp::RemoveGroupOp(const ChannelPtr &channel)
 {
     Contacts contacts = channel->groupContacts();
     if (!contacts.isEmpty()) {
-        connect(channel->groupRemoveContacts(contacts.toList()),
+        connect(channel->groupRemoveContacts(contacts.values()),
                 SIGNAL(finished(Tp::PendingOperation*)),
                 SLOT(onContactsRemoved(Tp::PendingOperation*)));
     } else {

--- a/TelepathyQt/contact-manager.cpp
+++ b/TelepathyQt/contact-manager.cpp
@@ -174,7 +174,7 @@ void ContactManager::PendingRefreshContactInfo::refreshInfo()
         mConn->interface<Client::ConnectionInterfaceContactInfoInterface>();
     Q_ASSERT(contactInfoInterface);
     PendingVoid *nested = new PendingVoid(
-            contactInfoInterface->RefreshContactInfo(mToRequest.toList()),
+            contactInfoInterface->RefreshContactInfo(mToRequest.values()),
             mConn);
     connect(nested,
             SIGNAL(finished(Tp::PendingOperation*)),
@@ -1044,7 +1044,7 @@ PendingContacts *ContactManager::contactsForHandles(const UIntList &handles,
 
     PendingContacts *contacts =
         new PendingContacts(ContactManagerPtr(this), handles, features, missingFeatures,
-                interfaces.toList(), satisfyingContacts, otherContacts);
+                interfaces.values(), satisfyingContacts, otherContacts);
     return contacts;
 }
 
@@ -1118,7 +1118,7 @@ PendingContacts *ContactManager::contactsForVCardAddresses(const QString &vcardF
     QSet<QString> interfaces = mPriv->interfacesForFeatures(realFeatures);
 
     PendingContacts *contacts = new PendingContacts(ContactManagerPtr(this), vcardField,
-            vcardAddresses, realFeatures, interfaces.toList());
+            vcardAddresses, realFeatures, interfaces.values());
     return contacts;
 }
 
@@ -1154,7 +1154,7 @@ PendingContacts *ContactManager::contactsForUris(const QStringList &uris,
     QSet<QString> interfaces = mPriv->interfacesForFeatures(realFeatures);
 
     PendingContacts *contacts = new PendingContacts(ContactManagerPtr(this), uris,
-            PendingContacts::ForUris, realFeatures, interfaces.toList());
+            PendingContacts::ForUris, realFeatures, interfaces.values());
     return contacts;
 }
 

--- a/TelepathyQt/contact-manager.cpp
+++ b/TelepathyQt/contact-manager.cpp
@@ -1216,7 +1216,11 @@ void ContactManager::requestContactAvatars(const QList<ContactPtr> &contacts)
         QTimer::singleShot(0, this, SLOT(doRequestAvatars()));
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    mPriv->requestAvatarsQueue.unite(Contacts(contacts.begin(), contacts.end()));
+#else
     mPriv->requestAvatarsQueue.unite(contacts.toSet());
+#endif
 }
 
 /**

--- a/TelepathyQt/contact.cpp
+++ b/TelepathyQt/contact.cpp
@@ -891,7 +891,7 @@ PendingOperation *Contact::unblock()
  */
 QStringList Contact::groups() const
 {
-    return mPriv->groups.toList();
+    return mPriv->groups.values();
 }
 
 /**

--- a/TelepathyQt/contact.cpp
+++ b/TelepathyQt/contact.cpp
@@ -1102,7 +1102,12 @@ void Contact::augment(const Features &requestedFeatures, const QVariantMap &attr
         } else if (feature == FeatureRosterGroups) {
             QStringList groups = qdbus_cast<QStringList>(attributes.value(
                         TP_QT_IFACE_CONNECTION_INTERFACE_CONTACT_GROUPS + QLatin1String("/groups")));
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+            mPriv->groups = groups.isEmpty() ? QSet<QString>() :
+                    QSet<QString>(groups.begin(), groups.end());
+#else
             mPriv->groups = groups.toSet();
+#endif
         } else if (feature == FeatureAddresses) {
             VCardFieldAddressMap addresses = qdbus_cast<VCardFieldAddressMap>(attributes.value(
                         TP_QT_IFACE_CONNECTION_INTERFACE_ADDRESSING + QLatin1String("/addresses")));

--- a/TelepathyQt/feature.cpp
+++ b/TelepathyQt/feature.cpp
@@ -64,7 +64,7 @@ Feature::~Feature()
 
 Feature &Feature::operator=(const Feature &other)
 {
-    *this = other;
+    QPair<QString, uint>::operator=(other);
     this->mPriv = other.mPriv;
     return *this;
 }

--- a/TelepathyQt/incoming-stream-tube-channel.cpp
+++ b/TelepathyQt/incoming-stream-tube-channel.cpp
@@ -42,7 +42,7 @@ struct TP_QT_NO_EXPORT IncomingStreamTubeChannel::Private
 
     // Public object
     IncomingStreamTubeChannel *parent;
-    static bool initRandom;
+    static bool initRandom; // can be removed with Qt < 5.10 support
 };
 
 bool IncomingStreamTubeChannel::Private::initRandom = true;
@@ -385,11 +385,15 @@ PendingStreamTubeConnection *IncomingStreamTubeChannel::acceptTubeAsUnixSocket(
     if (accessControl == SocketAccessControlLocalhost) {
         accessControlParam.setVariant(QVariant::fromValue(static_cast<uint>(0)));
     } else if (accessControl == SocketAccessControlCredentials) {
+#if QT_VERSION > QT_VERSION_CHECK(5, 10, 0)
+        credentialByte = static_cast<uchar>(QRandomGenerator::global()->bounded(UCHAR_MAX));
+#else
         if (mPriv->initRandom) {
             qsrand(QTime::currentTime().msec());
             mPriv->initRandom = false;
         }
         credentialByte = static_cast<uchar>(qrand());
+#endif
         accessControlParam.setVariant(QVariant::fromValue(credentialByte));
     } else {
         Q_ASSERT(false);

--- a/TelepathyQt/pending-captchas.cpp
+++ b/TelepathyQt/pending-captchas.cpp
@@ -214,8 +214,16 @@ void PendingCaptchas::onGetCaptchasWatcherFinished(QDBusPendingCallWatcher *watc
             // No preference, let's take the first of the list
             mimeType = info.availableMIMETypes.first();
         } else {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+            auto preferred = QSet<QString>(mPriv->preferredMimeTypes.begin(),
+                    mPriv->preferredMimeTypes.end());
+            auto available = QSet<QString>(info.availableMIMETypes.begin(),
+                    info.availableMIMETypes.end());
+            QSet<QString> supportedMimeTypes = available.intersect(preferred);
+#else
             QSet<QString> supportedMimeTypes = info.availableMIMETypes.toSet().intersect(
                     mPriv->preferredMimeTypes.toSet());
+#endif
             if (supportedMimeTypes.isEmpty()) {
                 // Apparently our handler does not support any of this captcha's mimetypes, skip
                 continue;

--- a/TelepathyQt/pending-contacts.cpp
+++ b/TelepathyQt/pending-contacts.cpp
@@ -197,7 +197,7 @@ PendingContacts::PendingContacts(const ContactManagerPtr &manager,
         ConnectionPtr conn = manager->connection();
         if (conn->interfaces().contains(TP_QT_IFACE_CONNECTION_INTERFACE_CONTACTS)) {
             PendingContactAttributes *attributes =
-                conn->lowlevel()->contactAttributes(otherContacts.toList(),
+                conn->lowlevel()->contactAttributes(otherContacts.values(),
                         interfaces, true);
 
             connect(attributes,
@@ -206,7 +206,7 @@ PendingContacts::PendingContacts(const ContactManagerPtr &manager,
         } else {
             // fallback to just create the contacts
             PendingHandles *handles = conn->lowlevel()->referenceHandles(HandleTypeContact,
-                    otherContacts.toList());
+                    otherContacts.values());
             connect(handles,
                     SIGNAL(finished(Tp::PendingOperation*)),
                     SLOT(onReferenceHandlesFinished(Tp::PendingOperation*)));
@@ -708,7 +708,7 @@ void PendingAddressingGetContacts::onGetContactsFinished(QDBusPendingCallWatcher
 
         mValidHandles = requested.values();
         mValidAddresses = requested.keys();
-        mInvalidAddresses = mAddresses.toSet().subtract(mValidAddresses.toSet()).toList();
+        mInvalidAddresses = mAddresses.toSet().subtract(mValidAddresses.toSet()).values();
         mAttributes = reply.argumentAt<1>();
         setFinished();
     } else {

--- a/TelepathyQt/pending-contacts.cpp
+++ b/TelepathyQt/pending-contacts.cpp
@@ -708,7 +708,15 @@ void PendingAddressingGetContacts::onGetContactsFinished(QDBusPendingCallWatcher
 
         mValidHandles = requested.values();
         mValidAddresses = requested.keys();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        auto addresses = mAddresses.isEmpty() ? QSet<QString>() :
+                QSet<QString>(mAddresses.begin(), mAddresses.end());
+        if (!mValidAddresses.isEmpty())
+            addresses.subtract(QSet<QString>(mValidAddresses.begin(), mValidAddresses.end()));
+        mInvalidAddresses = addresses.values();
+#else
         mInvalidAddresses = mAddresses.toSet().subtract(mValidAddresses.toSet()).values();
+#endif
         mAttributes = reply.argumentAt<1>();
         setFinished();
     } else {

--- a/TelepathyQt/profile.cpp
+++ b/TelepathyQt/profile.cpp
@@ -33,7 +33,6 @@
 #include <QFileInfo>
 #include <QStringList>
 #include <QXmlAttributes>
-#include <QXmlDefaultHandler>
 #include <QXmlInputSource>
 #include <QXmlSimpleReader>
 
@@ -97,35 +96,34 @@ void Profile::Private::Data::clear()
 }
 
 
-class TP_QT_NO_EXPORT Profile::Private::XmlHandler :
-                public QXmlDefaultHandler
+class TP_QT_NO_EXPORT Profile::Private::XmlHandler
 {
 public:
     XmlHandler(const QString &serviceName, bool allowNonIMType, Profile::Private::Data *outputData);
 
-    bool startElement(const QString &namespaceURI, const QString &localName,
-            const QString &qName, const QXmlAttributes &attributes) override;
-    bool endElement(const QString &namespaceURI, const QString &localName,
-            const QString &qName) override;
-    bool characters(const QString &str) override;
-    bool fatalError(const QXmlParseException &exception) override;
-    QString errorString() const override;
+    bool parse(QXmlStreamReader *reader);
+    QString errorString() const;
 
 private:
-    bool attributeValueAsBoolean(const QXmlAttributes &attributes,
+    bool attributeValueAsBoolean(const QXmlStreamAttributes &attributes,
             const QString &qName);
 
     QString mServiceName;
     bool allowNonIMType;
     Profile::Private::Data *mData;
-    QStack<QString> mElements;
-    QString mCurrentText;
+
+    bool parseServiceElem(QXmlStreamReader *reader);
+    bool parseParametersElem(QXmlStreamReader *reader);
+    bool parseParamElem(QXmlStreamReader *reader);
+    bool parsePresencesElem(QXmlStreamReader *reader);
+    bool parsePresenceElem(QXmlStreamReader *reader);
+    bool parseUnsupportedCCsElem(QXmlStreamReader *reader);
+    bool parseCCElem(QXmlStreamReader *reader);
+    bool parsePropElem(QXmlStreamReader *reader);
+
     Profile::Parameter mCurrentParameter;
     RequestableChannelClass mCurrentCC;
-    QString mCurrentPropertyName;
-    QString mCurrentPropertyType;
     QString mErrorString;
-    bool mMetServiceTag;
 
     static const QString xmlNs;
 
@@ -178,59 +176,36 @@ const QString Profile::Private::XmlHandler::elemAttrIcon = QLatin1String("icon")
 const QString Profile::Private::XmlHandler::elemAttrMessage = QLatin1String("message");
 const QString Profile::Private::XmlHandler::elemAttrDisabled = QLatin1String("disabled");
 
+
 Profile::Private::XmlHandler::XmlHandler(const QString &serviceName,
         bool allowNonIMType,
         Profile::Private::Data *outputData)
     : mServiceName(serviceName),
       allowNonIMType(allowNonIMType),
-      mData(outputData),
-      mMetServiceTag(false)
+      mData(outputData)
 {
 }
 
-bool Profile::Private::XmlHandler::startElement(const QString &namespaceURI,
-        const QString &localName, const QString &qName,
-        const QXmlAttributes &attributes)
-{
-    if (!mMetServiceTag && qName != elemService) {
-        mErrorString = QLatin1String("the file is not a profile file");
-        return false;
-    }
-
-    if (namespaceURI != xmlNs) {
-        // ignore all elements with unknown xmlns
-        debug() << "Ignoring unknown xmlns" << namespaceURI;
-        return true;
-    }
-
-#define CHECK_ELEMENT_IS_CHILD_OF(parentElement) \
-    if (mElements.top() != parentElement) { \
-        mErrorString = QString(QLatin1String("element '%1' is not a " \
-                    "child of element '%2'")) \
-            .arg(qName) \
-            .arg(parentElement); \
-        return false; \
-    }
 #define CHECK_ELEMENT_ATTRIBUTES_COUNT(value) \
     if (attributes.count() != value) { \
         mErrorString = QString(QLatin1String("element '%1' contains more " \
                     "than %2 attributes")) \
-            .arg(qName) \
+            .arg(reader->name()) \
             .arg(value); \
         return false; \
     }
 #define CHECK_ELEMENT_HAS_ATTRIBUTE(attribute) \
-    if (attributes.index(attribute) == -1) { \
+    if (!attributes.hasAttribute(attribute)) { \
         mErrorString = QString(QLatin1String("mandatory attribute '%1' " \
                     "missing on element '%2'")) \
             .arg(attribute) \
-            .arg(qName); \
+            .arg(reader->name()); \
         return false; \
     }
 #define CHECK_ELEMENT_ATTRIBUTES(allowedAttrs) \
     for (int i = 0; i < attributes.count(); ++i) { \
         bool valid = false; \
-        QString attrName = attributes.qName(i); \
+        QString attrName; attrName.append(attributes.at(i).name()); \
         foreach (const QString &allowedAttr, allowedAttrs) { \
             if (attrName == allowedAttr) { \
                 valid = true; \
@@ -241,12 +216,16 @@ bool Profile::Private::XmlHandler::startElement(const QString &namespaceURI,
             mErrorString = QString(QLatin1String("invalid attribute '%1' on " \
                         "element '%2'")) \
                 .arg(attrName) \
-                .arg(qName); \
+                .arg(reader->name()); \
             return false; \
         } \
     }
 
-    if (qName == elemService) {
+bool Profile::Private::XmlHandler::parseServiceElem(QXmlStreamReader *reader)
+{
+    const QXmlStreamAttributes &attributes = reader->attributes();
+
+    if (reader->name() == elemService) {
         CHECK_ELEMENT_HAS_ATTRIBUTE(elemAttrId);
         CHECK_ELEMENT_HAS_ATTRIBUTE(elemAttrType);
         CHECK_ELEMENT_HAS_ATTRIBUTE(elemAttrManager);
@@ -265,135 +244,205 @@ bool Profile::Private::XmlHandler::startElement(const QString &namespaceURI,
             return false;
         }
 
-        mMetServiceTag = true;
-        mData->type = attributes.value(elemAttrType);
+        mData->type = attributes.value(elemAttrType).toString();
         if (mData->type != QLatin1String("IM") && !allowNonIMType) {
             mErrorString = QString(QLatin1String("unknown value of element "
                         "'type': %1"))
-                .arg(mCurrentText);
+                .arg(mData->type);
             return false;
         }
-        mData->provider = attributes.value(elemAttrProvider);
-        mData->cmName = attributes.value(elemAttrManager);
-        mData->protocolName = attributes.value(elemAttrProtocol);
-        mData->iconName = attributes.value(elemAttrIcon);
-    } else if (qName == elemParams) {
-        CHECK_ELEMENT_IS_CHILD_OF(elemService);
+        mData->provider = attributes.value(elemAttrProvider).toString();
+        mData->cmName = attributes.value(elemAttrManager).toString();
+        mData->protocolName = attributes.value(elemAttrProtocol).toString();
+        mData->iconName = attributes.value(elemAttrIcon).toString();
+    } else {
+        Tp::warning() << "Ignoring unknown element" << reader->name();
+        reader->skipCurrentElement();
+    }
+
+    return true;
+}
+
+bool Profile::Private::XmlHandler::parseParametersElem(QXmlStreamReader *reader)
+{
+    const QXmlStreamAttributes &attributes = reader->attributes();
+
+    if (reader->name() == elemParams) {
         CHECK_ELEMENT_ATTRIBUTES_COUNT(0);
-    } else if (qName == elemParam) {
-        CHECK_ELEMENT_IS_CHILD_OF(elemParams);
+
+        do {
+            while (reader->readNextStartElement()) {
+                if (!parseParamElem(reader))
+                    return false;
+            }
+
+            // try again if we hit the end element of a child node
+        } while (!reader->hasError() && reader->name() != elemParams);
+    } else {
+        Tp::warning() << "Ignoring unknown element" << reader->name();
+        reader->skipCurrentElement();
+    }
+
+    return true;
+}
+
+bool Profile::Private::XmlHandler::parseParamElem(QXmlStreamReader *reader)
+{
+    const QXmlStreamAttributes &attributes = reader->attributes();
+
+    if (reader->name() == elemParam) {
         CHECK_ELEMENT_HAS_ATTRIBUTE(elemAttrName);
         QStringList allowedAttrs = QStringList() << elemAttrName <<
             elemAttrType << elemAttrMandatory << elemAttrLabel;
         CHECK_ELEMENT_ATTRIBUTES(allowedAttrs);
 
-        QString paramType = attributes.value(elemAttrType);
+        QString paramType = attributes.value(elemAttrType).toString();
         if (paramType.isEmpty()) {
             paramType = QLatin1String("s");
         }
-        mCurrentParameter.setName(attributes.value(elemAttrName));
+        mCurrentParameter.setName(attributes.value(elemAttrName).toString());
         mCurrentParameter.setDBusSignature(QDBusSignature(paramType));
-        mCurrentParameter.setLabel(attributes.value(elemAttrLabel));
+        mCurrentParameter.setLabel(attributes.value(elemAttrLabel).toString());
         mCurrentParameter.setMandatory(attributeValueAsBoolean(attributes,
                     elemAttrMandatory));
-    } else if (qName == elemPresences) {
-        CHECK_ELEMENT_IS_CHILD_OF(elemService);
+        const QString &currentText =
+                reader->readElementText(QXmlStreamReader::SkipChildElements);
+        mCurrentParameter.setValue(parseValueWithDBusSignature(currentText,
+                    mCurrentParameter.dbusSignature().signature()));
+        mData->parameters.append(Profile::Parameter(mCurrentParameter));
+    } else {
+        Tp::warning() << "Ignoring unknown element" << reader->name();
+        reader->skipCurrentElement();
+    }
+
+    return true;
+}
+
+bool Profile::Private::XmlHandler::parsePresencesElem(QXmlStreamReader *reader)
+{
+    const QXmlStreamAttributes &attributes = reader->attributes();
+
+    if (reader->name() == elemPresences) {
         QStringList allowedAttrs = QStringList() << elemAttrAllowOthers;
         CHECK_ELEMENT_ATTRIBUTES(allowedAttrs);
 
         mData->allowOtherPresences = attributeValueAsBoolean(attributes,
                 elemAttrAllowOthers);
-    } else if (qName == elemPresence) {
-        CHECK_ELEMENT_IS_CHILD_OF(elemPresences);
+
+        do {
+            while (reader->readNextStartElement()) {
+                if (!parsePresenceElem(reader))
+                    return false;
+            }
+
+            // try again if we hit the end element of a child node
+        } while (!reader->hasError() && reader->name() != elemPresences);
+    } else {
+        Tp::warning() << "Ignoring unknown element" << reader->name();
+        reader->skipCurrentElement();
+    }
+
+    return true;
+}
+
+bool Profile::Private::XmlHandler::parsePresenceElem(QXmlStreamReader *reader)
+{
+    const QXmlStreamAttributes &attributes = reader->attributes();
+
+    if (reader->name() == elemPresence) {
         CHECK_ELEMENT_HAS_ATTRIBUTE(elemAttrId);
         QStringList allowedAttrs = QStringList() << elemAttrId <<
             elemAttrLabel << elemAttrIcon << elemAttrMessage <<
             elemAttrDisabled;
         CHECK_ELEMENT_ATTRIBUTES(allowedAttrs);
-
         mData->presences.append(Profile::Presence(
-                    attributes.value(elemAttrId),
-                    attributes.value(elemAttrLabel),
-                    attributes.value(elemAttrIcon),
-                    attributes.value(elemAttrMessage),
+                    attributes.value(elemAttrId).toString(),
+                    attributes.value(elemAttrLabel).toString(),
+                    attributes.value(elemAttrIcon).toString(),
+                    attributes.value(elemAttrMessage).toString(),
                     attributeValueAsBoolean(attributes, elemAttrDisabled)));
-    } else if (qName == elemUnsupportedCCs) {
-        CHECK_ELEMENT_IS_CHILD_OF(elemService);
+    } else {
+        Tp::warning() << "Ignoring unknown element" << reader->name();
+        reader->skipCurrentElement();
+    }
+
+    return true;
+}
+
+bool Profile::Private::XmlHandler::parseUnsupportedCCsElem(QXmlStreamReader *reader)
+{
+    const QXmlStreamAttributes &attributes = reader->attributes();
+
+    if (reader->name() == elemUnsupportedCCs) {
         CHECK_ELEMENT_ATTRIBUTES_COUNT(0);
-    } else if (qName == elemCC) {
-        CHECK_ELEMENT_IS_CHILD_OF(elemUnsupportedCCs);
+
+        do {
+            while (reader->readNextStartElement()) {
+                if (!parseCCElem(reader))
+                    return false;
+            }
+
+            // try again if we hit the end element of a child node
+        } while (!reader->hasError() && reader->name() != elemUnsupportedCCs);
+    } else {
+        Tp::warning() << "Ignoring unknown element" << reader->name();
+        reader->skipCurrentElement();
+    }
+
+    return true;
+}
+
+bool Profile::Private::XmlHandler::parseCCElem(QXmlStreamReader *reader)
+{
+    const QXmlStreamAttributes &attributes = reader->attributes();
+
+    if (reader->name() == elemCC) {
         CHECK_ELEMENT_ATTRIBUTES_COUNT(0);
-    } else if (qName == elemProperty) {
-        CHECK_ELEMENT_IS_CHILD_OF(elemCC);
+
+        do {
+            while (reader->readNextStartElement()) {
+                if (!parsePropElem(reader))
+                    return false;
+            }
+            // try again if we hit the end element of a child node
+        } while (!reader->hasError() && reader->name() != elemCC);
+
+        mData->unsupportedChannelClassSpecs.append(RequestableChannelClassSpec(mCurrentCC));
+        mCurrentCC.fixedProperties.clear();
+    } else {
+        Tp::warning() << "Ignoring unknown element" << reader->name();
+        reader->skipCurrentElement();
+    }
+
+    return true;
+}
+
+bool Profile::Private::XmlHandler::parsePropElem(QXmlStreamReader *reader)
+{
+    const QXmlStreamAttributes &attributes = reader->attributes();
+
+    if (reader->name() == elemProperty) {
         CHECK_ELEMENT_ATTRIBUTES_COUNT(2);
         CHECK_ELEMENT_HAS_ATTRIBUTE(elemAttrName);
         CHECK_ELEMENT_HAS_ATTRIBUTE(elemAttrType);
 
-        mCurrentPropertyName = attributes.value(elemAttrName);
-        mCurrentPropertyType = attributes.value(elemAttrType);
+        QString propertyName = attributes.value(elemAttrName).toString();
+        QString propertyType = attributes.value(elemAttrType).toString();
+        const QString &propertyText =
+                reader->readElementText(QXmlStreamReader::SkipChildElements);
+        mCurrentCC.fixedProperties[propertyName] =
+            parseValueWithDBusSignature(propertyText, propertyType);
     } else {
-        if (qName != elemName) {
-            Tp::warning() << "Ignoring unknown element" << qName;
-        } else {
-            // check if we are inside <service>
-            CHECK_ELEMENT_IS_CHILD_OF(elemService);
-            // no element here supports attributes
-            CHECK_ELEMENT_ATTRIBUTES_COUNT(0);
-        }
+        Tp::warning() << "Ignoring unknown element" << reader->name();
+        reader->skipCurrentElement();
     }
 
-#undef CHECK_ELEMENT_IS_CHILD_OF
+    return true;
+}
+
 #undef CHECK_ELEMENT_ATTRIBUTES_COUNT
 #undef CHECK_ELEMENT_HAS_ATTRIBUTE
 #undef CHECK_ELEMENT_ATTRIBUTES
-
-    mElements.push(qName);
-    mCurrentText.clear();
-    return true;
-}
-
-bool Profile::Private::XmlHandler::endElement(const QString &namespaceURI,
-        const QString &localName, const QString &qName)
-{
-    if (namespaceURI != xmlNs) {
-        // ignore all elements with unknown xmlns
-        debug() << "Ignoring unknown xmlns" << namespaceURI;
-        return true;
-    } else if (qName == elemName) {
-        mData->name = mCurrentText;
-    } else if (qName == elemParam) {
-        mCurrentParameter.setValue(parseValueWithDBusSignature(mCurrentText,
-                    mCurrentParameter.dbusSignature().signature()));
-        mData->parameters.append(Profile::Parameter(mCurrentParameter));
-    } else if (qName == elemCC) {
-        mData->unsupportedChannelClassSpecs.append(RequestableChannelClassSpec(mCurrentCC));
-        mCurrentCC.fixedProperties.clear();
-    } else if (qName == elemProperty) {
-        mCurrentCC.fixedProperties[mCurrentPropertyName] =
-            parseValueWithDBusSignature(mCurrentText,
-                    mCurrentPropertyType);
-    }
-
-    mElements.pop();
-    return true;
-}
-
-bool Profile::Private::XmlHandler::characters(const QString &str)
-{
-    mCurrentText += str;
-    return true;
-}
-
-bool Profile::Private::XmlHandler::fatalError(
-        const QXmlParseException &exception)
-{
-    mErrorString = QString(QLatin1String("parse error at line %1, column %2: "
-                "%3"))
-        .arg(exception.lineNumber())
-        .arg(exception.columnNumber())
-        .arg(exception.message());
-    return false;
-}
 
 QString Profile::Private::XmlHandler::errorString() const
 {
@@ -401,9 +450,9 @@ QString Profile::Private::XmlHandler::errorString() const
 }
 
 bool Profile::Private::XmlHandler::attributeValueAsBoolean(
-        const QXmlAttributes &attributes, const QString &qName)
+        const QXmlStreamAttributes &attributes, const QString &qName)
 {
-    QString tmpStr = attributes.value(qName);
+    QString tmpStr = attributes.value(qName).toString();
     if (tmpStr == QLatin1String("1") ||
         tmpStr == QLatin1String("true")) {
         return true;
@@ -411,7 +460,6 @@ bool Profile::Private::XmlHandler::attributeValueAsBoolean(
         return false;
     }
 }
-
 
 Profile::Private::Private()
     : valid(false),
@@ -488,20 +536,79 @@ void Profile::Private::lookupProfile()
     }
 }
 
+bool Profile::Private::XmlHandler::parse(QXmlStreamReader *reader)
+{
+    if (!reader->readNextStartElement() || !reader->isStartElement() ||
+            reader->namespaceUri() != xmlNs || reader->name() != elemService) {
+        mErrorString = QString(QLatin1String("the file is not a profile file"));
+        return false;
+    }
+
+    // top level element should be <service id=[...] >
+    if (!parseServiceElem(reader))
+        return false;
+
+    while (reader->readNextStartElement()) {
+        if (reader->namespaceUri() != xmlNs) {
+            // ignore all elements with unknown xmlns
+            debug() << "Ignoring unknown xmlns" << reader->namespaceUri();
+            continue;
+        }
+
+        if (reader->name() == elemName) {
+            // <name> foo </name>
+            mData->name = reader->readElementText(QXmlStreamReader::SkipChildElements);
+        } else if (reader->name() == elemParams) {
+            // <parameters>
+            //   <parameter name=[...] > foo </parameter>
+            //   <parameter name=[...] />
+            // </parameters>
+            if (!parseParametersElem(reader))
+                return false;
+        } else if (reader->name() == elemPresences) {
+            // <presences allow-others="1">
+            //   <presence id=[...] />
+            // </presences>
+            if (!parsePresencesElem(reader))
+                return false;
+        } else if (reader->name() == elemUnsupportedCCs) {
+            // <unsupported-channel-classes>
+            //   <channel-class>
+            //     <property name=[...]>1</property>
+            //     <property name=[...]>Channel.Type.Text</property>
+            //   </channel-class>
+            //   <channel-class>
+            //     [...]
+            //   </channel-class>
+            // </unsupported-channel-classes>
+            if (!parseUnsupportedCCsElem(reader))
+                return false;
+        } else {
+            Tp::warning() << "Ignoring unknown element" << reader->name() << " in main loop";
+            reader->skipCurrentElement();
+        }
+    }
+    if (reader->hasError()) {
+        mErrorString = QString(QLatin1String(
+                    "parse error at line %1, column %2: %3"))
+            .arg(reader->lineNumber())
+            .arg(reader->columnNumber())
+            .arg(reader->errorString());
+        return false;
+    }
+
+    return true;
+}
+
 bool Profile::Private::parse(QFile *file)
 {
     invalidate();
 
     fake = false;
-    QFileInfo fi(file->fileName());
     XmlHandler xmlHandler(serviceName, allowNonIMType, &data);
+    QXmlStreamReader reader(file);
 
-    QXmlSimpleReader xmlReader;
-    xmlReader.setContentHandler(&xmlHandler);
-    xmlReader.setErrorHandler(&xmlHandler);
-
-    QXmlInputSource xmlInputSource(file);
-    if (!xmlReader.parse(xmlInputSource)) {
+    if (!xmlHandler.parse(&reader)) {
         warning() << QString(QLatin1String("Error parsing profile file %1: %2"))
             .arg(file->fileName())
             .arg(xmlHandler.errorString());

--- a/TelepathyQt/referenced-handles.h
+++ b/TelepathyQt/referenced-handles.h
@@ -225,7 +225,12 @@ public:
 
     inline QSet<uint> toSet() const
     {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        auto h = toList();
+        return h.isEmpty() ? QSet<uint>() : QSet<uint>(h.begin(), h.end());
+#else
         return toList().toSet();
+#endif
     }
 
 #ifndef QT_NO_STL

--- a/TelepathyQt/referenced-handles.h
+++ b/TelepathyQt/referenced-handles.h
@@ -231,9 +231,14 @@ public:
 #ifndef QT_NO_STL
     inline std::list<uint> toStdList() const
     {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        auto l = toList();
+        return l.isEmpty() ? std::list<uint>() : std::list<uint>(l.begin(), l.end());
+#else
         return toList().toStdList();
+#endif // !(QT_VERSION >= 5.14.0)
     }
-#endif
+#endif // !QT_NO_STL
 
     inline QVector<uint> toVector() const
     {

--- a/TelepathyQt/shared-ptr.h
+++ b/TelepathyQt/shared-ptr.h
@@ -109,7 +109,7 @@ public:
         if (sc) {
             // increase the strongref, but never up from zero
             // or less (negative is used on untracked objects)
-            register int tmp = sc->strongref.fetchAndAddOrdered(0);
+            int tmp = sc->strongref.fetchAndAddOrdered(0);
             while (tmp > 0) {
                 // try to increment from "tmp" to "tmp + 1"
                 if (sc->strongref.testAndSetRelaxed(tmp, tmp + 1)) {

--- a/TelepathyQt/simple-observer-internal.h
+++ b/TelepathyQt/simple-observer-internal.h
@@ -152,7 +152,12 @@ public:
     QSet<ChannelClassFeatures> extraChannelFeatures() const { return mExtraChannelFeatures; }
     void registerExtraChannelFeatures(const QList<ChannelClassFeatures> &features)
     {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        mExtraChannelFeatures.unite(features.isEmpty() ? QSet<ChannelClassFeatures>() :
+                QSet<ChannelClassFeatures>(features.begin(), features.end()));
+#else
         mExtraChannelFeatures.unite(features.toSet());
+#endif
     }
 
     QSet<AccountPtr> accounts() const { return mAccounts; }

--- a/TelepathyQt/simple-observer.cpp
+++ b/TelepathyQt/simple-observer.cpp
@@ -56,7 +56,12 @@ SimpleObserver::Private::Private(SimpleObserver *parent,
       contactIdentifier(contactIdentifier),
       extraChannelFeatures(extraChannelFeatures)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    QSet<ChannelClassSpec> normalizedChannelFilter = channelFilter.isEmpty() ? QSet<ChannelClassSpec>() :
+            QSet<ChannelClassSpec>(channelFilter.begin(), channelFilter.end());
+#else
     QSet<ChannelClassSpec> normalizedChannelFilter = channelFilter.toSet();
+#endif
     QPair<QString, QSet<ChannelClassSpec> > observerUniqueId(
             account->dbusConnection().baseService(), normalizedChannelFilter);
     observer = SharedPtr<Observer>(observers.value(observerUniqueId));

--- a/TelepathyQt/simple-observer.cpp
+++ b/TelepathyQt/simple-observer.cpp
@@ -76,7 +76,7 @@ SimpleObserver::Private::Private(SimpleObserver *parent,
                 .replace(QLatin1String("."), QLatin1String("_")))
             .arg(numObservers++);
         observer = SharedPtr<Observer>(new Observer(cr, fakeAccountFactory,
-                    normalizedChannelFilter.toList(), observerName));
+                    normalizedChannelFilter.values(), observerName));
         if (!cr->registerClient(observer, observerName, false)) {
             warning() << "Unable to register observer" << observerName;
             observer.reset();
@@ -146,7 +146,7 @@ void SimpleObserver::Private::insertChannels(const AccountPtr &channelsAccount,
     }
 
     channels.unite(match);
-    emit parent->newChannels(match.toList());
+    emit parent->newChannels(match.values());
 }
 
 void SimpleObserver::Private::removeChannel(const AccountPtr &channelAccount,
@@ -529,7 +529,7 @@ QList<ChannelClassFeatures> SimpleObserver::extraChannelFeatures() const
  */
 QList<ChannelPtr> SimpleObserver::channels() const
 {
-    return mPriv->channels.toList();
+    return mPriv->channels.values();
 }
 
 /**

--- a/TelepathyQt/simple-stream-tube-handler.cpp
+++ b/TelepathyQt/simple-stream-tube-handler.cpp
@@ -37,21 +37,21 @@ namespace Tp
 
 namespace
 {
-    ChannelClassSpecList buildFilter(const QStringList &p2pServices,
-            const QStringList &roomServices, bool requested)
+    ChannelClassSpecList buildFilter(QStringList p2pServices,
+            QStringList roomServices, bool requested)
     {
         ChannelClassSpecList filter;
 
-        // Convert to QSet to weed out duplicates
-        foreach (const QString &service, p2pServices.toSet())
+        p2pServices.removeDuplicates();
+        foreach (const QString &service, p2pServices)
         {
             filter.append(requested ?
                     ChannelClassSpec::outgoingStreamTube(service) :
                     ChannelClassSpec::incomingStreamTube(service));
         }
 
-        // Convert to QSet to weed out duplicates
-        foreach (const QString &service, roomServices.toSet())
+        roomServices.removeDuplicates();
+        foreach (const QString &service, roomServices)
         {
             filter.append(requested ?
                     ChannelClassSpec::outgoingRoomStreamTube(service) :

--- a/TelepathyQt/simple-stream-tube-handler.cpp
+++ b/TelepathyQt/simple-stream-tube-handler.cpp
@@ -153,7 +153,7 @@ void SimpleStreamTubeHandler::handleChannels(
         invocation->hints = requestsSatisfied.first()->hints();
     }
 
-    mInvocations.append(invocation);
+    mInvocations.push_back(invocation);
 
     if (invocation->tubes.isEmpty()) {
         warning() << "SSTH::HandleChannels got no suitable channels, admitting we're Confused";
@@ -171,29 +171,31 @@ void SimpleStreamTubeHandler::handleChannels(
 
 void SimpleStreamTubeHandler::onReadyOpFinished(Tp::PendingOperation *op)
 {
-    Q_ASSERT(!mInvocations.isEmpty());
+    Q_ASSERT(!mInvocations.empty());
     Q_ASSERT(!op || op->isFinished());
 
-    for (QLinkedList<SharedPtr<InvocationData> >::iterator i = mInvocations.begin();
-            op != nullptr && i != mInvocations.end(); ++i) {
-        if ((*i)->readyOp != op) {
+    for (const auto &i : mInvocations) {
+        if (op == nullptr)
+            break;
+        if (i->readyOp != op) {
             continue;
         }
 
-        (*i)->readyOp = nullptr;
+        i->readyOp = nullptr;
 
         if (op->isError()) {
             warning() << "Preparing proxies for SSTubeHandler failed with" << op->errorName()
                 << op->errorMessage();
-            (*i)->error = op->errorName();
-            (*i)->message = op->errorMessage();
+            i->error = op->errorName();
+            i->message = op->errorMessage();
         }
 
         break;
     }
 
-    while (!mInvocations.isEmpty() && !mInvocations.first()->readyOp) {
-        SharedPtr<InvocationData> invocation = mInvocations.takeFirst();
+    while (!mInvocations.empty() && !mInvocations.front()->readyOp) {
+        auto invocation = mInvocations.front();
+	mInvocations.pop_front();
 
         if (!invocation->error.isEmpty()) {
             // We guarantee that the proxies were ready - so we can't invoke the client if they

--- a/TelepathyQt/simple-stream-tube-handler.h
+++ b/TelepathyQt/simple-stream-tube-handler.h
@@ -29,10 +29,11 @@
 #include <TelepathyQt/Types>
 
 #include <QDateTime>
-#include <QLinkedList>
 #include <QHash>
 #include <QQueue>
 #include <QSet>
+
+#include <list>
 
 namespace Tp
 {
@@ -110,7 +111,7 @@ private:
         QDateTime time;
         ChannelRequestHints hints;
     };
-    QLinkedList<SharedPtr<InvocationData> > mInvocations;
+    std::list<SharedPtr<InvocationData> > mInvocations;
     QHash<StreamTubeChannelPtr, AccountPtr> mTubes;
     bool mBypassApproval;
 };

--- a/TelepathyQt/text-channel.cpp
+++ b/TelepathyQt/text-channel.cpp
@@ -457,7 +457,7 @@ void TextChannel::Private::processChatStateQueue()
     // TODO: pass id hints to ContactManager if we ever gain support to retrieve contact ids
     //       from ChatState.
     parent->connect(parent->connection()->contactManager()->contactsForHandles(
-                contactsRequired.toList()),
+                contactsRequired.values()),
             SIGNAL(finished(Tp::PendingOperation*)),
             SLOT(onContactsFinished(Tp::PendingOperation*)));
 

--- a/TelepathyQt/text-channel.cpp
+++ b/TelepathyQt/text-channel.cpp
@@ -123,8 +123,8 @@ TextChannel::Private::Private(TextChannel *parent)
       readinessHelper(parent->readinessHelper()),
       getAllInFlight(false),
       gotProperties(false),
-      messagePartSupport(nullptr),
-      deliveryReportingSupport(nullptr),
+      messagePartSupport(MessagePartSupportFlags()),
+      deliveryReportingSupport(DeliveryReportingSupportFlags()),
       initialMessagesReceived(false)
 {
     ReadinessHelper::Introspectables introspectables;
@@ -1130,7 +1130,7 @@ void TextChannel::onPendingMessagesRemoved(const UIntList &ids)
 
 void TextChannel::onTextSent(uint timestamp, uint type, const QString &text)
 {
-    emit messageSent(Message(timestamp, type, text), nullptr,
+    emit messageSent(Message(timestamp, type, text), MessageSendingFlags(),
             QLatin1String(""));
 }
 

--- a/TelepathyQt/text-channel.cpp
+++ b/TelepathyQt/text-channel.cpp
@@ -1200,7 +1200,7 @@ void TextChannel::onTextSendError(uint error, uint timestamp, uint type,
 
     header.insert(QLatin1String("message-received"),
             QDBusVariant(static_cast<qlonglong>(
-#if QT_VERSION_CHECK(5, 8, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 8, 0)
                     QDateTime::currentDateTime().toTime_t())));
 #else
                     QDateTime::currentDateTime().toSecsSinceEpoch())));

--- a/TelepathyQt/text-channel.cpp
+++ b/TelepathyQt/text-channel.cpp
@@ -410,12 +410,16 @@ void TextChannel::Private::processMessageQueue()
     ConnectionPtr conn = parent->connection();
     conn->lowlevel()->injectContactIds(contactsRequired);
 
-    parent->connect(conn->contactManager()->contactsForHandles(
-                contactsRequired.keys()),
+    auto contactKeys = contactsRequired.keys();
+    parent->connect(conn->contactManager()->contactsForHandles(contactKeys),
             SIGNAL(finished(Tp::PendingOperation*)),
             SLOT(onContactsFinished(Tp::PendingOperation*)));
 
-    awaitingContacts |= contactsRequired.keys().toSet();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    awaitingContacts |= QSet<uint>(contactKeys.begin(), contactKeys.end());
+#else
+    awaitingContacts |= contactKeys.toSet();
+#endif
 }
 
 void TextChannel::Private::processChatStateQueue()

--- a/TelepathyQt/utils.cpp
+++ b/TelepathyQt/utils.cpp
@@ -102,7 +102,7 @@ QString escapeAsIdentifier(const QString &string)
             }
 
             /* escape the unsafe character */
-            qsnprintf(buf, sizeof (buf), "_%02x", (unsigned char)(*ptr));
+            std::snprintf(buf, sizeof (buf), "_%02x", (unsigned char)(*ptr));
             op.append(buf);
 
             /* restart after it */

--- a/tests/channel-class-spec.cpp
+++ b/tests/channel-class-spec.cpp
@@ -13,7 +13,11 @@ ChannelClassSpecList reverse(const ChannelClassSpecList &list)
 {
     ChannelClassSpecList ret(list);
     for (int k = 0; k < (list.size() / 2); k++) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0)
+        ret.swapItemsAt(k, list.size() - (1 + k));
+#else
         ret.swap(k, list.size() - (1 + k));
+#endif
     }
     return ret;
 }

--- a/tests/dbus/account-channel-dispatcher.cpp
+++ b/tests/dbus/account-channel-dispatcher.cpp
@@ -576,7 +576,7 @@ void TestAccountChannelDispatcher::testPCR(PendingChannelRequest *pcr)
     QVERIFY(connect(pcr,
                     SIGNAL(finished(Tp::PendingOperation *)),
                     SLOT(onPendingChannelRequestFinished(Tp::PendingOperation *))));
-    mLoop->exec(0);
+    mLoop->exec();
 
     mChannelRequest = pcr->channelRequest();
 
@@ -593,7 +593,7 @@ void TestAccountChannelDispatcher::testPCR(PendingChannelRequest *pcr)
         QVERIFY(connect(mChannelRequest->becomeReady(),
                         SIGNAL(finished(Tp::PendingOperation *)),
                         SLOT(expectSuccessfulCall(Tp::PendingOperation *))));
-        mLoop->exec(0);
+        mLoop->exec();
         QCOMPARE(mChannelRequest->userActionTime(), mUserActionTime);
         QCOMPARE(mChannelRequest->account().data(), mAccount.data());
 
@@ -611,7 +611,7 @@ void TestAccountChannelDispatcher::testPC(PendingChannel *pc, PendingChannel **p
     QVERIFY(connect(pc,
                     SIGNAL(finished(Tp::PendingOperation *)),
                     SLOT(onPendingChannelFinished(Tp::PendingOperation *))));
-    mLoop->exec(0);
+    mLoop->exec();
 
     ChannelPtr channel = pc->channel();
     if (channelOut) {

--- a/tests/dbus/account-channel-dispatcher.cpp
+++ b/tests/dbus/account-channel-dispatcher.cpp
@@ -1090,7 +1090,7 @@ void TestAccountChannelDispatcher::testCreateAndHandleChannelHandledAgain()
     connect(notifier,
             SIGNAL(handledAgain(QDateTime,Tp::ChannelRequestHints)),
             SLOT(onChannelHandledAgain(QDateTime,Tp::ChannelRequestHints)));
-    QDateTime timestamp(QDate::currentDate());
+    QDateTime timestamp(QDateTime::fromSecsSinceEpoch(QDateTime::currentSecsSinceEpoch()));
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 8, 0)
     mChannelDispatcherAdaptor->invokeHandler(timestamp.toTime_t());

--- a/tests/dbus/account-set.cpp
+++ b/tests/dbus/account-set.cpp
@@ -258,7 +258,12 @@ void TestAccountSet::testFilters()
     createAccount("spurious", "normal", "spuriousnormal", parameters);
     QCOMPARE(mAM->allAccounts().size(), 2);
     QCOMPARE(mAM->validAccounts()->accounts().size(), 2);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    auto all = mAM->allAccounts();
+    AccountPtr spuriousAcc = *(QSet<AccountPtr>(all.begin(), all.end()) -= fooAcc).begin();
+#else
     AccountPtr spuriousAcc = *(mAM->allAccounts().toSet() -= fooAcc).begin();
+#endif
 
     Tp::AccountSetPtr filteredAccountSet;
 

--- a/tests/dbus/call-channel.cpp
+++ b/tests/dbus/call-channel.cpp
@@ -272,7 +272,7 @@ void TestCallChannel::init()
     mContentRemoved.reset();
     mCallStateReason = CallStateReason();
     mCallState = CallStateUnknown;
-    mCallFlags = (CallFlags) nullptr;
+    mCallFlags = CallFlags();
     mRemoteMemberFlags.clear();
     mRemoteMembersRemoved.clear();
     mLSSCReturn = (Tp::SendingState) -1;

--- a/tests/dbus/chan-conference.cpp
+++ b/tests/dbus/chan-conference.cpp
@@ -95,7 +95,7 @@ void TestConferenceChan::initTestCase()
     guint handle3 = tp_handle_ensure(mContactRepo, "someone3@localhost", nullptr, nullptr);
 
     QByteArray chanPath;
-    GPtrArray *initialChannels = g_ptr_array_new();
+    GPtrArray *initialChannels = g_ptr_array_new_with_free_func((GDestroyNotify) g_free);
 
     mTextChan1Path = mConn->objectPath() + QLatin1String("/TextChannel/1");
     chanPath = mTextChan1Path.toLatin1();
@@ -136,7 +136,6 @@ void TestConferenceChan::initTestCase()
                 "initial-channels", initialChannels,
                 NULL));
 
-    g_ptr_array_foreach(initialChannels, (GFunc) g_free, nullptr);
     g_ptr_array_free(initialChannels, TRUE);
 }
 

--- a/tests/dbus/chan-group.cpp
+++ b/tests/dbus/chan-group.cpp
@@ -26,9 +26,9 @@ public:
     TestChanGroup(QObject *parent = nullptr)
         : Test(parent), mConn(nullptr), mChanService(nullptr),
           mGotGroupFlagsChanged(false),
-          mGroupFlags((ChannelGroupFlags) nullptr),
-          mGroupFlagsAdded((ChannelGroupFlags) nullptr),
-          mGroupFlagsRemoved((ChannelGroupFlags) nullptr)
+          mGroupFlags(ChannelGroupFlags()),
+          mGroupFlagsAdded(ChannelGroupFlags()),
+          mGroupFlagsRemoved(ChannelGroupFlags())
     { }
 
 protected Q_SLOTS:
@@ -158,9 +158,9 @@ void TestChanGroup::init()
     mChangedRemoved.clear();
     mDetails = Channel::GroupMemberChangeDetails();
     mGotGroupFlagsChanged = false;
-    mGroupFlags = (ChannelGroupFlags) nullptr;
-    mGroupFlagsAdded = (ChannelGroupFlags) nullptr;
-    mGroupFlagsRemoved = (ChannelGroupFlags) nullptr;
+    mGroupFlags = ChannelGroupFlags();
+    mGroupFlagsAdded = ChannelGroupFlags();
+    mGroupFlagsRemoved = ChannelGroupFlags();
 }
 
 void TestChanGroup::testCreateChannel()
@@ -481,7 +481,7 @@ void TestChanGroup::testGroupFlagsChange()
     QVERIFY(textChan->groupFlags() & ChannelGroupFlagCanAdd);
     QVERIFY(textChan->canInviteContacts());
     QCOMPARE(mGroupFlagsAdded, ChannelGroupFlagCanAdd);
-    QCOMPARE(mGroupFlagsRemoved, (ChannelGroupFlags) nullptr);
+    QCOMPARE(mGroupFlagsRemoved, ChannelGroupFlags());
 }
 
 void TestChanGroup::cleanup()

--- a/tests/dbus/cm-protocol.cpp
+++ b/tests/dbus/cm-protocol.cpp
@@ -452,16 +452,16 @@ struct CMHelper
         ProtocolPropertiesMap protocols;
         QVariantMap immutableProperties;
         if (withProtocolProps) {
-            immutableProperties.unite(protocolAdaptor->immutableProperties());
+            immutableProperties.insert(protocolAdaptor->immutableProperties());
         }
         if (withProtocolAddressingProps) {
-            immutableProperties.unite(protocolAddressingAdaptor->immutableProperties());
+            immutableProperties.insert(protocolAddressingAdaptor->immutableProperties());
         }
         if (withProtocolAvatarsProps) {
-            immutableProperties.unite(protocolAvatarsAdaptor->immutableProperties());
+            immutableProperties.insert(protocolAvatarsAdaptor->immutableProperties());
         }
         if (withProtocolPresenceProps) {
-            immutableProperties.unite(protocolPresenceAdaptor->immutableProperties());
+            immutableProperties.insert(protocolPresenceAdaptor->immutableProperties());
         }
         protocols.insert(cmName, immutableProperties);
 

--- a/tests/dbus/conn-roster-groups.cpp
+++ b/tests/dbus/conn-roster-groups.cpp
@@ -425,7 +425,7 @@ void TestConnRosterGroups::testRosterGroups()
 
     causeCongestion(mConn, mConn->selfContact());
 
-    QVERIFY(connect(contactManager->addContactsToGroup(group, contacts.toList()),
+    QVERIFY(connect(contactManager->addContactsToGroup(group, contacts.values()),
                     SIGNAL(finished(Tp::PendingOperation*)),
                     SLOT(expectSuccessfulCall(Tp::PendingOperation*))));
     QCOMPARE(mLoop->exec(), 0);
@@ -446,7 +446,7 @@ void TestConnRosterGroups::testRosterGroups()
 
     causeCongestion(mConn, mConn->selfContact());
 
-    QVERIFY(connect(contactManager->removeContactsFromGroup(group, contacts.toList()),
+    QVERIFY(connect(contactManager->removeContactsFromGroup(group, contacts.values()),
                     SIGNAL(finished(Tp::PendingOperation*)),
                     SLOT(expectSuccessfulCall(Tp::PendingOperation*))));
     QCOMPARE(mLoop->exec(), 0);

--- a/tests/dbus/conn-roster-legacy.cpp
+++ b/tests/dbus/conn-roster-legacy.cpp
@@ -422,7 +422,11 @@ void TestConnRosterLegacy::testRoster()
                             Tp::Channel::GroupMemberChangeDetails))));
 
     mBlockingContactsFinished = false;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    mContactsExpectingBlockStatusChange = QSet<QString>(ids.begin(), ids.end());
+#else
     mContactsExpectingBlockStatusChange = ids.toSet();
+#endif
 
     QVERIFY(connect(contactManager->blockContacts(contacts),
                     SIGNAL(finished(Tp::PendingOperation*)),
@@ -441,7 +445,11 @@ void TestConnRosterLegacy::testRoster()
 
     // now unblock them again
     mBlockingContactsFinished = false;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    mContactsExpectingBlockStatusChange = QSet<QString>(ids.begin(), ids.end());
+#else
     mContactsExpectingBlockStatusChange = ids.toSet();
+#endif
 
     QVERIFY(connect(contactManager->unblockContacts(contacts),
             SIGNAL(finished(Tp::PendingOperation*)),

--- a/tests/dbus/conn-roster-legacy.cpp
+++ b/tests/dbus/conn-roster-legacy.cpp
@@ -337,7 +337,7 @@ void TestConnRosterLegacy::testRoster()
     QCOMPARE(ids, toCheck);
 
     // block all contacts
-    QList<ContactPtr> contactsList = contactManager->allKnownContacts().toList();
+    QList<ContactPtr> contactsList = contactManager->allKnownContacts().values();
     QSet<QString> contactIdsList;
     Q_FOREACH (const ContactPtr &contact, contactsList) {
         QVERIFY(connect(contact.data(),

--- a/tests/dbus/conn-roster.cpp
+++ b/tests/dbus/conn-roster.cpp
@@ -358,7 +358,7 @@ void TestConnRoster::testRoster()
     QCOMPARE(ids, toCheck);
 
     // block all contacts
-    QList<ContactPtr> contactsList = contactManager->allKnownContacts().toList();
+    QList<ContactPtr> contactsList = contactManager->allKnownContacts().values();
     QSet<QString> contactIdsList;
     Q_FOREACH (const ContactPtr &contact, contactsList) {
         QVERIFY(connect(contact.data(),

--- a/tests/dbus/conn-roster.cpp
+++ b/tests/dbus/conn-roster.cpp
@@ -443,7 +443,11 @@ void TestConnRoster::testRoster()
                             Tp::Channel::GroupMemberChangeDetails))));
 
     mBlockingContactsFinished = false;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    mContactsExpectingBlockStatusChange = QSet<QString>(ids.begin(), ids.end());
+#else
     mContactsExpectingBlockStatusChange = ids.toSet();
+#endif
 
     QVERIFY(connect(contactManager->blockContacts(contacts),
                     SIGNAL(finished(Tp::PendingOperation*)),
@@ -462,7 +466,11 @@ void TestConnRoster::testRoster()
 
     // now unblock them again
     mBlockingContactsFinished = false;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    mContactsExpectingBlockStatusChange = QSet<QString>(ids.begin(), ids.end());
+#else
     mContactsExpectingBlockStatusChange = ids.toSet();
+#endif
 
     QVERIFY(connect(contactManager->unblockContacts(contacts),
             SIGNAL(finished(Tp::PendingOperation*)),

--- a/tests/dbus/contacts-avatar.cpp
+++ b/tests/dbus/contacts-avatar.cpp
@@ -14,41 +14,6 @@
 
 using namespace Tp;
 
-class SmartDir : public QDir
-{
-public:
-    SmartDir(const QString &path) : QDir(path) { }
-    bool rmdir() { return QDir().rmdir(path()); }
-    bool removeDirectory();
-};
-
-bool SmartDir::removeDirectory()
-{
-    bool ret = true;
-
-    QFileInfoList list = entryInfoList(QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot);
-    Q_FOREACH (QFileInfo info, list) {
-        if (info.isDir()) {
-            SmartDir subDir(info.filePath());
-            if (!subDir.removeDirectory()) {
-                ret = false;
-            }
-        } else {
-            qDebug() << "deleting" << info.filePath();
-            if (!QFile(info.filePath()).remove()) {
-                ret = false;
-            }
-        }
-    }
-
-    if (ret) {
-        qDebug() << "deleting" << path();
-        ret = rmdir();
-    }
-
-    return ret;
-}
-
 class TestContactsAvatar : public Test
 {
     Q_OBJECT
@@ -79,6 +44,7 @@ private:
     QList<ContactPtr> mContacts;
     bool mGotAvatarRetrieved;
     int mAvatarDatasChanged;
+    QTemporaryDir mTmpDir;
 };
 
 void TestContactsAvatar::onAvatarRetrieved(uint handle, const QString &token,
@@ -173,24 +139,16 @@ void TestContactsAvatar::init()
 
     mGotAvatarRetrieved = false;
     mAvatarDatasChanged = 0;
+
+    /* Make sure our tests does not mess up user's avatar cache */
+    QVERIFY(mTmpDir.isValid());
+    setenv ("XDG_CACHE_HOME", qPrintable(mTmpDir.path()), true);
 }
 
 void TestContactsAvatar::testAvatar()
 {
     QVERIFY(mConn->client()->contactManager()->supportedFeatures().contains(
                 Contact::FeatureAvatarData));
-
-    /* Make sure our tests does not mess up user's avatar cache */
-    qsrand(time(nullptr));
-    static const char letters[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    static const int DirNameLength = 6;
-    QString dirName;
-    for (int i = 0; i < DirNameLength; ++i) {
-        dirName += QLatin1Char(letters[qrand() % qstrlen(letters)]);
-    }
-    QString tmpDir = QString(QLatin1String("%1/%2")).arg(QDir::tempPath()).arg(dirName);
-    QByteArray a = tmpDir.toLatin1();
-    setenv ("XDG_CACHE_HOME", a.constData(), true);
 
     Client::ConnectionInterfaceAvatarsInterface *connAvatarsInterface =
         mConn->client()->optionalInterface<Client::ConnectionInterfaceAvatarsInterface>();
@@ -211,8 +169,6 @@ void TestContactsAvatar::testAvatar()
     mGotAvatarRetrieved = false;
     createContactWithFakeAvatar("bar");
     QVERIFY(!mGotAvatarRetrieved);
-
-    QVERIFY(SmartDir(tmpDir).removeDirectory());
 }
 
 void TestContactsAvatar::testRequestAvatars()

--- a/tests/features.cpp
+++ b/tests/features.cpp
@@ -22,6 +22,15 @@ QList<Feature> reverse(const QList<Feature> &list)
     return ret;
 }
 
+QSet<Feature> makeSet(const QList<Feature> &list)
+{
+#if QT_VERSION > QT_VERSION_CHECK(5, 14, 0)
+    return QSet<Feature>(list.begin(), list.end());
+#else
+    return list.toSet();
+#endif
+}
+
 };
 
 class TestFeatures : public QObject
@@ -51,7 +60,7 @@ void TestFeatures::testFeaturesHash()
         fs2 << Feature(QString::number(i), i);
     }
 
-    QCOMPARE(qHash(fs1.toSet()), qHash(fs2.toSet()));
+    QCOMPARE(qHash(makeSet(fs1)), qHash(makeSet(fs2)));
 
     fs2.clear();
     for (int i = 0; i < 5; ++i) {
@@ -60,16 +69,16 @@ void TestFeatures::testFeaturesHash()
         }
     }
 
-    QCOMPARE(qHash(fs1.toSet()), qHash(fs2.toSet()));
+    QCOMPARE(qHash(makeSet(fs1)), qHash(makeSet(fs2)));
 
     fs1 = reverse(fs1);
-    QCOMPARE(qHash(fs1.toSet()), qHash(fs2.toSet()));
+    QCOMPARE(qHash(makeSet(fs1)), qHash(makeSet(fs2)));
 
     fs2 = reverse(fs2);
-    QCOMPARE(qHash(fs1.toSet()), qHash(fs2.toSet()));
+    QCOMPARE(qHash(makeSet(fs1)), qHash(makeSet(fs2)));
 
     fs2 << Feature(QLatin1String("100"), 100);
-    QVERIFY(qHash(fs1.toSet()) != qHash(fs2.toSet()));
+    QVERIFY(qHash(makeSet(fs1)) != qHash(makeSet(fs2)));
 }
 
 QTEST_MAIN(TestFeatures)

--- a/tests/lib/glib/call/call-channel.c
+++ b/tests/lib/glib/call/call-channel.c
@@ -675,8 +675,8 @@ call_hangup (TpBaseCallChannel *base,
 static TpBaseCallContent *
 call_add_content (TpBaseCallChannel *base,
     const gchar *content_name,
-    guint content_type,
-      TpMediaStreamDirection initial_direction,
+    TpMediaStreamType content_type,
+    TpMediaStreamDirection initial_direction,
     GError **error)
 {
   ExampleCallChannel *self = EXAMPLE_CALL_CHANNEL (base);

--- a/tests/lib/glib/call/call-manager.c
+++ b/tests/lib/glib/call/call-manager.c
@@ -359,12 +359,15 @@ static const gchar * const audio_fixed_properties[] = {
     NULL
 };
 
+/* No need to also check video fixed props; audio is enough.
+ *
 static const gchar * const video_fixed_properties[] = {
     TP_PROP_CHANNEL_CHANNEL_TYPE,
     TP_PROP_CHANNEL_TARGET_HANDLE_TYPE,
     TP_PROP_CHANNEL_TYPE_CALL_INITIAL_VIDEO,
     NULL
 };
+*/
 
 static const gchar * const audio_allowed_properties[] = {
     TP_PROP_CHANNEL_TARGET_HANDLE,

--- a/tests/lib/glib/callable/media-channel.c
+++ b/tests/lib/glib/callable/media-channel.c
@@ -778,7 +778,7 @@ media_list_streams (TpSvcChannelTypeStreamedMedia *iface,
 
   tp_svc_channel_type_streamed_media_return_from_list_streams (context,
       array);
-  g_ptr_array_foreach (array, (GFunc) g_value_array_free, NULL);
+  g_ptr_array_set_free_func (array, (GDestroyNotify) g_value_array_free);
   g_ptr_array_free (array, TRUE);
 }
 

--- a/tests/lib/glib/contacts-conn.c
+++ b/tests/lib/glib/contacts-conn.c
@@ -623,7 +623,7 @@ tp_tests_contacts_connection_change_aliases (TpTestsContactsConnection *self,
   tp_svc_connection_interface_aliasing_emit_aliases_changed (self,
       structs);
 
-  g_ptr_array_foreach (structs, (GFunc) g_value_array_free, NULL);
+  g_ptr_array_set_free_func (structs, (GDestroyNotify) g_value_array_free);
   g_ptr_array_free (structs, TRUE);
 }
 


### PR DESCRIPTION
This is the first batch of a bunch of TelepathyQt warning fixes. These are mostly for deprecation warnings, especially for things that are dropped with Qt6. I'm testing this on debian unstable, building against Qt 5.15.17.

I specifically avoided anything that might change the API or ABI.