### PR TITLE
tests: fix crash related to PendingOperation race

### DIFF
--- a/tests/dbus/conn-basics.cpp
+++ b/tests/dbus/conn-basics.cpp
@@ -97,6 +97,7 @@ void TestConnBasics::expectPresenceAvailable(const Tp::SimplePresence &presence)
 
 void TestConnBasics::onRequestConnectFinished(Tp::PendingOperation *op)
 {
+    TEST_VERIFY_OP(op);
     QCOMPARE(mConn->status(), ConnectionStatusConnected);
     QVERIFY(mStatuses.contains(ConnectionStatusConnected));
     mLoop->exit(0);
@@ -149,19 +150,15 @@ void TestConnBasics::init()
                     SLOT(expectConnReady(Tp::ConnectionStatus))));
 
     qDebug() << "waiting connection to become connected";
-    PendingOperation *pr = mConn->becomeReady(Connection::FeatureConnected);
-    QVERIFY(connect(pr,
+    QVERIFY(connect(mConn->becomeReady(Connection::FeatureConnected),
                     SIGNAL(finished(Tp::PendingOperation*)),
                     SLOT(expectSuccessfulCall(Tp::PendingOperation*))));
 
-    PendingOperation *pc = mConn->lowlevel()->requestConnect();
-    QVERIFY(connect(pc,
+    QVERIFY(connect(mConn->lowlevel()->requestConnect(),
                     SIGNAL(finished(Tp::PendingOperation*)),
                     SLOT(onRequestConnectFinished(Tp::PendingOperation*))));
     QCOMPARE(mLoop->exec(), 0);
-    QCOMPARE(pr->isFinished(), true);
     QCOMPARE(mLoop->exec(), 0);
-    QCOMPARE(pc->isFinished(), true);
     QCOMPARE(mConn->isReady(Connection::FeatureConnected), true);
     qDebug() << "connection is now ready";
 

--- a/tests/dbus/conn-introspect-cornercases.cpp
+++ b/tests/dbus/conn-introspect-cornercases.cpp
@@ -141,9 +141,7 @@ void TestConnIntrospectCornercases::testSelfHandleChangeBeforeConnecting()
                     SLOT(expectSuccessfulCall(Tp::PendingOperation*))));
 
     QCOMPARE(mLoop->exec(), 0);
-    QVERIFY(op->isFinished());
     QVERIFY(mConn->isValid());
-    QVERIFY(op->isValid());
 
     QCOMPARE(static_cast<uint>(mConn->status()),
              static_cast<uint>(Tp::ConnectionStatusConnecting));
@@ -166,7 +164,6 @@ void TestConnIntrospectCornercases::testSelfHandleChangeBeforeConnecting()
     // Try to finish the SelfContact operation, running the mainloop for a while
 
     QCOMPARE(mLoop->exec(), 0);
-    QCOMPARE(op->isFinished(), true);
     QCOMPARE(mConn->isReady(Connection::FeatureCore), true);
     QCOMPARE(mConn->isReady(Connection::FeatureSelfContact), true);
     QCOMPARE(static_cast<uint>(mConn->status()),
@@ -205,15 +202,12 @@ void TestConnIntrospectCornercases::testSelfHandleChangeWhileBuilding()
 
     // Make the conn Connected, and with FeatureCore ready
 
-    PendingOperation *op = mConn->lowlevel()->requestConnect();
-    QVERIFY(connect(op,
+    QVERIFY(connect(mConn->lowlevel()->requestConnect(),
                     SIGNAL(finished(Tp::PendingOperation*)),
                     SLOT(expectSuccessfulCall(Tp::PendingOperation*))));
 
     QCOMPARE(mLoop->exec(), 0);
-    QVERIFY(op->isFinished());
     QVERIFY(mConn->isValid());
-    QVERIFY(op->isValid());
 
     QCOMPARE(static_cast<uint>(mConn->status()),
              static_cast<uint>(Tp::ConnectionStatusConnected));
@@ -223,8 +217,7 @@ void TestConnIntrospectCornercases::testSelfHandleChangeWhileBuilding()
 
     // Start introspecting the SelfContact feature
 
-    op = mConn->becomeReady(Connection::FeatureSelfContact);
-    QVERIFY(connect(op,
+    QVERIFY(connect(mConn->becomeReady(Connection::FeatureSelfContact),
                     SIGNAL(finished(Tp::PendingOperation*)),
                     SLOT(expectSuccessfulCall(Tp::PendingOperation*))));
 
@@ -236,7 +229,6 @@ void TestConnIntrospectCornercases::testSelfHandleChangeWhileBuilding()
 
     // Try to finish the SelfContact operation, running the mainloop for a while
     QCOMPARE(mLoop->exec(), 0);
-    QCOMPARE(op->isFinished(), true);
     QCOMPARE(mConn->isReady(Connection::FeatureCore), true);
     QCOMPARE(mConn->isReady(Connection::FeatureSelfContact), true);
     QCOMPARE(static_cast<uint>(mConn->status()),
@@ -319,15 +311,13 @@ void TestConnIntrospectCornercases::testSlowpath()
     g_free(name); name = nullptr;
     g_free(connPath); connPath = nullptr;
 
-    PendingOperation *op = mConn->becomeReady();
-    QVERIFY(connect(op,
+    QVERIFY(connect(mConn->becomeReady(),
                     SIGNAL(finished(Tp::PendingOperation*)),
                     SLOT(expectSuccessfulCall(Tp::PendingOperation*))));
 
     tp_tests_bug16307_connection_inject_get_status_return(bugConnService);
 
     QCOMPARE(mLoop->exec(), 0);
-    QCOMPARE(op->isFinished(), true);
     QCOMPARE(mConn->isReady(Connection::FeatureCore), true);
     QCOMPARE(static_cast<uint>(mConn->status()),
              static_cast<uint>(ConnectionStatusConnected));
@@ -367,21 +357,18 @@ void TestConnIntrospectCornercases::testStatusChange()
     // during core introspection, and we rather want to test the more general ReadinessHelper
     // mechanism
 
-    PendingOperation *op = mConn->becomeReady();
-    QVERIFY(connect(op,
+    QVERIFY(connect(mConn->becomeReady(),
                     SIGNAL(finished(Tp::PendingOperation*)),
                     SLOT(expectSuccessfulCall(Tp::PendingOperation*))));
 
     QCOMPARE(mLoop->exec(), 0);
-    QCOMPARE(op->isFinished(), true);
     QCOMPARE(mConn->isReady(Connection::FeatureCore), true);
     QCOMPARE(static_cast<uint>(mConn->status()),
              static_cast<uint>(ConnectionStatusDisconnected));
 
     // Now, begin making Connected ready
 
-    op = mConn->becomeReady(Connection::FeatureConnected);
-    QVERIFY(connect(op,
+    QVERIFY(connect(mConn->becomeReady(Connection::FeatureConnected),
                     SIGNAL(finished(Tp::PendingOperation*)),
                     SLOT(expectSuccessfulCall(Tp::PendingOperation*))));
 
@@ -407,7 +394,6 @@ void TestConnIntrospectCornercases::testStatusChange()
             TP_CONNECTION_STATUS_REASON_REQUESTED);
 
     QCOMPARE(mLoop->exec(), 0);
-    QCOMPARE(op->isFinished(), true);
     QCOMPARE(mConn->isReady(Connection::FeatureCore), true);
     QCOMPARE(mConn->isReady(Connection::FeatureConnected), true);
     QCOMPARE(static_cast<uint>(mConn->status()),
@@ -444,19 +430,16 @@ void TestConnIntrospectCornercases::testNoRoster()
     g_free(name); name = nullptr;
     g_free(connPath); connPath = nullptr;
 
-    PendingOperation *op = mConn->lowlevel()->requestConnect();
-    QVERIFY(connect(op,
+    QVERIFY(connect(mConn->lowlevel()->requestConnect(),
                     SIGNAL(finished(Tp::PendingOperation*)),
                     SLOT(expectSuccessfulCall(Tp::PendingOperation*))));
     QCOMPARE(mLoop->exec(), 0);
     QCOMPARE(mConn->status(), Tp::ConnectionStatusConnected);
 
-    op = mConn->becomeReady(Connection::FeatureRoster);
-    QVERIFY(connect(op,
+    QVERIFY(connect(mConn->becomeReady(Connection::FeatureRoster),
                     SIGNAL(finished(Tp::PendingOperation*)),
                     SLOT(expectSuccessfulCall(Tp::PendingOperation*))));
     QCOMPARE(mLoop->exec(), 0);
-    QVERIFY(op->isFinished());
     QVERIFY(mConn->isReady(Connection::FeatureRoster));
     QVERIFY(!mConn->actualFeatures().contains(Connection::FeatureRoster));
 }

--- a/tests/dbus/streamed-media-chan.cpp
+++ b/tests/dbus/streamed-media-chan.cpp
@@ -1152,8 +1152,8 @@ void TestStreamedMediaChan::testHoldNoUnhold()
     // Request unhold (fail)
     QVERIFY(connect(mChan->requestHold(false),
                     SIGNAL(finished(Tp::PendingOperation*)),
-                    SLOT(expectSuccessfulCall(Tp::PendingOperation*))));
-    QCOMPARE(mLoop->exec(), 1);
+                    SLOT(expectFailure(Tp::PendingOperation*))));
+    QCOMPARE(mLoop->exec(), 0);
     QCOMPARE(mLocalHoldStates.size(), 0);
     QCOMPARE(mLocalHoldStateReasons.size(), 0);
     QCOMPARE(static_cast<uint>(mChan->localHoldState()), static_cast<uint>(LocalHoldStateHeld));
@@ -1296,14 +1296,14 @@ void TestStreamedMediaChan::testDTMF()
     // start dtmf (must fail)
     QVERIFY(connect(stream->startDTMFTone(DTMFEventDigit0),
                     SIGNAL(finished(Tp::PendingOperation*)),
-                    SLOT(expectSuccessfulCall(Tp::PendingOperation*))));
-    QCOMPARE(mLoop->exec(), 1);
+                    SLOT(expectFailure(Tp::PendingOperation*))));
+    QCOMPARE(mLoop->exec(), 0);
 
     // stop dtmf (must fail)
     QVERIFY(connect(stream->stopDTMFTone(),
                     SIGNAL(finished(Tp::PendingOperation*)),
-                    SLOT(expectSuccessfulCall(Tp::PendingOperation*))));
-    QCOMPARE(mLoop->exec(), 1);
+                    SLOT(expectFailure(Tp::PendingOperation*))));
+    QCOMPARE(mLoop->exec(), 0);
 }
 
 void TestStreamedMediaChan::testDTMFNoContinuousTone()
@@ -1347,8 +1347,8 @@ void TestStreamedMediaChan::testDTMFNoContinuousTone()
     // stop dtmf (must fail)
     QVERIFY(connect(stream->stopDTMFTone(),
                     SIGNAL(finished(Tp::PendingOperation*)),
-                    SLOT(expectSuccessfulCall(Tp::PendingOperation*))));
-    QCOMPARE(mLoop->exec(), 1);
+                    SLOT(expectFailure(Tp::PendingOperation*))));
+    QCOMPARE(mLoop->exec(), 0);
 }
 
 void TestStreamedMediaChan::cleanup()

--- a/tests/lib/test.cpp
+++ b/tests/lib/test.cpp
@@ -51,13 +51,7 @@ void Test::cleanupTestCaseImpl()
 
 void Test::expectSuccessfulCall(PendingOperation *op)
 {
-    if (op->isError()) {
-        qWarning().nospace() << op->errorName()
-            << ": " << op->errorMessage();
-        mLoop->exit(1);
-        return;
-    }
-
+    TEST_VERIFY_OP(op);
     mLoop->exit(0);
 }
 


### PR DESCRIPTION
https://telepathy.freedesktop.org/doc/telepathy-qt/a08676.html states:

"After finished() is emitted, the PendingOperation is automatically deleted using deleteLater(), so library users must not explicitly delete this object."

This also means that calling isValid() or isFinished() on the PendingOperation object after the signal handlers have completed can result in a crash depending on how quickly the object gets deleted after signal emission. This race doesn't happen frequently, but it *does* happen:

QFATAL : TestConnBasics::testBasics() Received signal 11
         Function time: 2ms Total time: 4ms
FAIL!  : TestConnBasics::testBasics() Received a fatal error.

We're already using QEventLoop::exec()s 'exit' value to identify problems in Test::expectSuccessfulCall(); we can extend that to do the isFinished check in the signal handler and return any errors. Plus, TEST_VERIFY_OP() is right there and does three checks (isFinished/isValid/isError) for us. Note that using TEST_VERIFY_OP changes the return values though, so TestStreamedMediaChan failure cases need to be modified to actually use the expectFailure slot instead of expecting a specific error code from expectSucceessfulCall.

TestConnBasics::onRequestConnectFinished() has the same issues, and can use the same strategy.