### PR TITLE
DRAFT: Various warning and Qt6 porting fixes that changes the ABI

### DIFF
--- a/TelepathyQt/contact-messenger.h
+++ b/TelepathyQt/contact-messenger.h
@@ -55,9 +55,9 @@ public:
 
     PendingSendMessage *sendMessage(const QString &text,
             ChannelTextMessageType type = ChannelTextMessageTypeNormal,
-            MessageSendingFlags flags = nullptr);
+            MessageSendingFlags flags = MessageSendingFlags());
     PendingSendMessage *sendMessage(const MessageContentPartList &parts,
-            MessageSendingFlags flags = nullptr);
+            MessageSendingFlags flags = MessageSendingFlags());
 
 Q_SIGNALS:
     void messageSent(const Tp::Message &message, Tp::MessageSendingFlags flags,

--- a/TelepathyQt/text-channel.h
+++ b/TelepathyQt/text-channel.h
@@ -78,10 +78,10 @@ public Q_SLOTS:
 
     PendingSendMessage *send(const QString &text,
             ChannelTextMessageType type = ChannelTextMessageTypeNormal,
-            MessageSendingFlags flags = nullptr);
+            MessageSendingFlags flags = MessageSendingFlags());
 
     PendingSendMessage *send(const MessagePartList &parts,
-            MessageSendingFlags flags = nullptr);
+            MessageSendingFlags flags = MessageSendingFlags());
 
     inline PendingOperation *inviteContacts(
             const QList<ContactPtr> &contacts,


### PR DESCRIPTION
This MR will include a bunch of fixes that modify the ABI. Rather than having a flag day to switch over, I'll probably go out of my way to do a bunch of #ifdefs to not change the ABI when built against Qt5; but I want to collect these in this branch before I do that. For now, I'm keeping them simple, uncluttered, and separate from https://github.com/TelepathyIM/telepathy-qt/pull/43.