### PR TITLE
Fix build failure when enabling tests

### DIFF
--- a/tools/glib-ginterface-gen.py
+++ b/tools/glib-ginterface-gen.py
@@ -731,6 +731,7 @@ class Generator(object):
 
         self.h('#include <glib-object.h>')
         self.h('#include <dbus/dbus-glib.h>')
+        self.h('#include <telepathy-glib/dbus.h>')
 
         for header in self.headers:
             self.h('#include %s' % header)


### PR DESCRIPTION
When I set -DENABLE_TESTS=YES, I hit the following build error:

/telepathy-qt/obj-x86_64-linux-gnu/tests/lib/glib/future/extensions/_gen/svc-connection.c: In function 'future_svc_connection_interface_addressing_get_contacts_by_vcard_field': /telepathy-qt/obj-x86_64-linux-gnu/tests/lib/glib/future/extensions/_gen/svc-connection.c:58:7: error: implicit declaration of function 'tp_dbus_g_method_return_not_implemented' [-Wimplicit-function-declaration]
   58 |       tp_dbus_g_method_return_not_implemented (context);

That source file is generated from
tests/lib/glib/future/extensions/connection.xml, so I think this is the correct fix?